### PR TITLE
fix(extensions.json): add `Catppuccin.catppuccin-vsc-icons`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,6 +15,7 @@
     "antfu.theme-vitesse",
     "file-icons.file-icons",
     "sainnhe.gruvbox-material",
+    "Catppuccin.catppuccin-vsc-icons",
 
     // life savers!
     "dbaeumer.vscode-eslint",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The extension `"Catppuccin.catppuccin-vsc-icons"` should be included in the list of extensions because in `settings.json` it is specified that `workbench.iconTheme` is `"catppuccin-mocha"`. This is a bug fix, because after I copied and pasted the `settings.json` into my VSCode, the line `"workbench.iconTheme": "catppuccin-mocha"` was giving a warning `File icon theme is unknown or not installed`, since it wasn't eventually on the list of extensions.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
